### PR TITLE
Resolved auto-refresh issue when a new game is added

### DIFF
--- a/src/AppControl.js
+++ b/src/AppControl.js
@@ -28,9 +28,10 @@ class AppControl extends Component {
     console.log(newGameObj);
     return GameData.post(newGameObj)
     .then(() =>
-    UsersManager.getUsersGames(this.state.userId).then(game =>
+    UsersManager.getUsersGames(parseInt(sessionStorage.getItem("user"))).then(game =>
       this.setState({
-        usersGames: game
+        // usersGames: game // User dash does not auto-refresh
+        games: game // This auto-refreshes user's dash.
       })
       ))
       .then(() => console.log("this.state.games:", this.state.games));
@@ -77,12 +78,6 @@ class AppControl extends Component {
         games: game
       })
     })
-    // .then(() => UsersManager.getUsersGames(this.state.userId))
-    // .then(usersGames => {
-    //   this.setState({
-    //     usersGames: usersGames
-    //   })
-    // })
   }
   //==============================================================================================
   //  LIFE CYCLE:


### PR DESCRIPTION
Resolved auto-refresh issue when a new game is added; games are still not user-specific on dashboard, however.

- Compared the functions in AppControl for deleting and editing a game to the method for adding a game
- In the addGame function, state was set to ```usersGames: game``` rather than ```games: game```
- By changing state to ```games: game``` like in the delete and edit functions, the user is automatically redirected to a refreshed dashboard with the latest card added.